### PR TITLE
Split music and sounds

### DIFF
--- a/Sound_Util.lua
+++ b/Sound_Util.lua
@@ -51,13 +51,13 @@ function Custom_Play_Sound(sound_code, stop_previous_instance, volume, pitch)
         volume = volume or 1
         s.sound:setPitch(pitch or 1)
 		
-	    local sound_vol = volume * (G.SETTINGS.SOUND.volume / 100.0)
+        local sound_vol = volume * (G.SETTINGS.SOUND.volume / 100.0)
 		
-	    if string.find(s.sound_code,'music') then
-	        sound_vol = sound_vol * (G.SETTINGS.SOUND.game_sounds_volume / 100.0)
-	    else
-	        sound_vol = sound_vol * (G.SETTINGS.SOUND.music_volume / 100.0)
-	    end
+        if string.find(s.sound_code,'music') then
+            sound_vol = sound_vol * (G.SETTINGS.SOUND.game_sounds_volume / 100.0)
+        else
+            sound_vol = sound_vol * (G.SETTINGS.SOUND.music_volume / 100.0)
+        end
 		
         if sound_vol <= 0 then
             s.sound:setVolume(0)

--- a/Sound_Util.lua
+++ b/Sound_Util.lua
@@ -50,7 +50,15 @@ function Custom_Play_Sound(sound_code, stop_previous_instance, volume, pitch)
         stop_previous_instance = stop_previous_instance and true
         volume = volume or 1
         s.sound:setPitch(pitch or 1)
-        local sound_vol = volume * (G.SETTINGS.SOUND.volume / 100.0) * (G.SETTINGS.SOUND.music_volume / 100.0)
+		
+		local sound_vol = volume * (G.SETTINGS.SOUND.volume / 100.0)
+		
+		if string.find(s.sound_code,'music') then
+			sound_vol = sound_vol * (G.SETTINGS.SOUND.game_sounds_volume / 100.0)
+		else
+			sound_vol = sound_vol * (G.SETTINGS.SOUND.music_volume / 100.0)
+		end
+		
         if sound_vol <= 0 then
             s.sound:setVolume(0)
         else

--- a/Sound_Util.lua
+++ b/Sound_Util.lua
@@ -51,13 +51,13 @@ function Custom_Play_Sound(sound_code, stop_previous_instance, volume, pitch)
         volume = volume or 1
         s.sound:setPitch(pitch or 1)
 		
-		local sound_vol = volume * (G.SETTINGS.SOUND.volume / 100.0)
+	    local sound_vol = volume * (G.SETTINGS.SOUND.volume / 100.0)
 		
-		if string.find(s.sound_code,'music') then
-			sound_vol = sound_vol * (G.SETTINGS.SOUND.game_sounds_volume / 100.0)
-		else
-			sound_vol = sound_vol * (G.SETTINGS.SOUND.music_volume / 100.0)
-		end
+	    if string.find(s.sound_code,'music') then
+	        sound_vol = sound_vol * (G.SETTINGS.SOUND.game_sounds_volume / 100.0)
+	    else
+	        sound_vol = sound_vol * (G.SETTINGS.SOUND.music_volume / 100.0)
+	    end
 		
         if sound_vol <= 0 then
             s.sound:setVolume(0)

--- a/sound.lua
+++ b/sound.lua
@@ -44,7 +44,15 @@ function Custom_Play_Sound(sound_code, stop_previous_instance, volume, pitch)
         stop_previous_instance = stop_previous_instance and true
         volume = volume or 1
         s.sound:setPitch(pitch or 1)
-        local sound_vol = volume * (G.SETTINGS.SOUND.volume / 100.0) * (G.SETTINGS.SOUND.music_volume / 100.0)
+		
+        local sound_vol = volume * (G.SETTINGS.SOUND.volume / 100.0)
+		
+		if string.find(s.sound_code,'music') then
+			sound_vol = sound_vol * (G.SETTINGS.SOUND.game_sounds_volume / 100.0)
+		else
+			sound_vol = sound_vol * (G.SETTINGS.SOUND.music_volume / 100.0)
+		end
+		
         if sound_vol <= 0 then
             s.sound:setVolume(0)
         else

--- a/sound.lua
+++ b/sound.lua
@@ -47,11 +47,11 @@ function Custom_Play_Sound(sound_code, stop_previous_instance, volume, pitch)
 		
         local sound_vol = volume * (G.SETTINGS.SOUND.volume / 100.0)
 		
-	    if string.find(s.sound_code,'music') then
-	        sound_vol = sound_vol * (G.SETTINGS.SOUND.game_sounds_volume / 100.0)
-	    else
-	        sound_vol = sound_vol * (G.SETTINGS.SOUND.music_volume / 100.0)
-	    end
+        if string.find(s.sound_code,'music') then
+            sound_vol = sound_vol * (G.SETTINGS.SOUND.game_sounds_volume / 100.0)
+        else
+            sound_vol = sound_vol * (G.SETTINGS.SOUND.music_volume / 100.0)
+        end
 		
         if sound_vol <= 0 then
             s.sound:setVolume(0)

--- a/sound.lua
+++ b/sound.lua
@@ -47,11 +47,11 @@ function Custom_Play_Sound(sound_code, stop_previous_instance, volume, pitch)
 		
         local sound_vol = volume * (G.SETTINGS.SOUND.volume / 100.0)
 		
-		if string.find(s.sound_code,'music') then
-			sound_vol = sound_vol * (G.SETTINGS.SOUND.game_sounds_volume / 100.0)
-		else
-			sound_vol = sound_vol * (G.SETTINGS.SOUND.music_volume / 100.0)
-		end
+	    if string.find(s.sound_code,'music') then
+	        sound_vol = sound_vol * (G.SETTINGS.SOUND.game_sounds_volume / 100.0)
+	    else
+	        sound_vol = sound_vol * (G.SETTINGS.SOUND.music_volume / 100.0)
+	    end
 		
         if sound_vol <= 0 then
             s.sound:setVolume(0)


### PR DESCRIPTION
Currently, all custom sounds are being played using the music_volume setting. This change makes it so only sounds with codes containing 'music' are played using the music_volume setting. Others are played using the game_sound_volume setting. This is the same method the base game uses to decide which volume is used for audio.